### PR TITLE
Initial support for building pages from repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,9 @@ jobs:
       - name: Install wkhtmltopdf
         run: |
           sudo apt update
-          sudo apt install -y wget
+          sudo apt install -y wget fontconfig fontconfig-config fonts-dejavu-core libbsd0 libexpat1 libfontconfig1 libfontenc1 libfreetype6 libjpeg-turbo8 libpng16-16 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxrender1 multiarch-support ucf x11-common xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils
           wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
           sudo dpkg -i wkhtmltox_0.12.5-1.bionic_amd64.deb
-          sudo apt --fix-broken install
       - name: Create output directory
         run: mkdir output
       - name: Create PDF file from .md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Create HTML file from .md
         uses: docker://pandoc/core:2.9
         with:
-          args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"
+          args: "--from markdown --to html --css ./styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"
       - name: Install SSH Client
         uses: webfactory/ssh-agent@v0.2.0
         with:
@@ -23,3 +23,18 @@ jobs:
           SSH: true
           BRANCH: gh-pages
           FOLDER: output
+
+  convert_to_pdf:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Create output directory
+        run: mkdir output
+      - name: Create PDF file from .md
+        uses: docker://pandoc/core:2.9
+        with:
+          args: "--from markdown --to pdf -t html --css ./styles.css --lua-filter ./pagebreak.lua -o output/cv.pdf --standalone index.md"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: CV
+          path: output/cv.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,22 +23,3 @@ jobs:
           SSH: true
           BRANCH: gh-pages
           FOLDER: output
-
-  convert_to_pdf:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install pandoc and wkhtmltopdf
-        run: |
-          sudo apt update
-          sudo apt install -y pandoc wget fontconfig fontconfig-config fonts-dejavu-core libbsd0 libexpat1 libfontconfig1 libfontenc1 libfreetype6 libjpeg-turbo8 libpng16-16 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxrender1 multiarch-support ucf x11-common xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils
-          wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
-          sudo dpkg -i wkhtmltox_0.12.5-1.bionic_amd64.deb
-      - name: Create output directory
-        run: mkdir output
-      - name: Create PDF file from .md
-        run: pandoc --from markdown --to pdf -t html --css ./styles.css --lua-filter ./pagebreak.lua -o output/cv.pdf --standalone index.md
-      - uses: actions/upload-artifact@v1
-        with:
-          name: CV
-          path: output/cv.pdf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,19 @@ name: CI
 on: [push]
 
 jobs:
-  convert_via_pandoc:
+  convert_to_html_for_pages:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: mkdir output && cp styles.css output
-      - uses: docker://pandoc/core:2.9
+      - name: Create output directory
+        run: mkdir output && cp styles.css output
+      - name: Create HTML file from .md
+        uses: docker://pandoc/core:2.9
         with:
           args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"
-      
+      - name: Deploy to pages branch
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install wkhtmltopdf
-        run: apt install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+        run: sudo apt install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
       - name: Create output directory
         run: mkdir output
       - name: Create PDF file from .md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ jobs:
   convert_via_pandoc:
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v1
+      - run: mkdir output && cp core-styles.css output
       - uses: docker://pandoc/core:2.9
         with:
-          args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o foo.html --standalone index.md"
+          args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"
+      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
+      - name: Install wkhtmltopdf
+        run: apt install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
       - name: Create output directory
         run: mkdir output
       - name: Create PDF file from .md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - run: mkdir output && cp core-styles.css output
+      - run: mkdir output && cp styles.css output
       - uses: docker://pandoc/core:2.9
         with:
           args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install wkhtmltopdf
-        run: sudo apt install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+        run: |
+          sudo apt update
+          sudo apt install -y wget
+          wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
+          sudo dpkg -i wkhtmltox_0.12.5-1.bionic_amd64.deb
+          sudo apt --fix-broken install
       - name: Create output directory
         run: mkdir output
       - name: Create PDF file from .md

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on: [push]
+
+jobs:
+  convert_via_pandoc:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: docker://pandoc/core:2.9
+        with:
+          args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o foo.html --standalone index.md"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,18 +28,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: Install wkhtmltopdf
+      - name: Install pandoc and wkhtmltopdf
         run: |
           sudo apt update
-          sudo apt install -y wget fontconfig fontconfig-config fonts-dejavu-core libbsd0 libexpat1 libfontconfig1 libfontenc1 libfreetype6 libjpeg-turbo8 libpng16-16 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxrender1 multiarch-support ucf x11-common xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils
+          sudo apt install -y pandoc wget fontconfig fontconfig-config fonts-dejavu-core libbsd0 libexpat1 libfontconfig1 libfontenc1 libfreetype6 libjpeg-turbo8 libpng16-16 libx11-6 libx11-data libxau6 libxcb1 libxdmcp6 libxext6 libxrender1 multiarch-support ucf x11-common xfonts-75dpi xfonts-base xfonts-encodings xfonts-utils
           wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb
           sudo dpkg -i wkhtmltox_0.12.5-1.bionic_amd64.deb
       - name: Create output directory
         run: mkdir output
       - name: Create PDF file from .md
-        uses: docker://pandoc/core:2.9
-        with:
-          args: "--from markdown --to pdf -t html --css ./styles.css --lua-filter ./pagebreak.lua -o output/cv.pdf --standalone index.md"
+        run: pandoc --from markdown --to pdf -t html --css ./styles.css --lua-filter ./pagebreak.lua -o output/cv.pdf --standalone index.md
       - uses: actions/upload-artifact@v1
         with:
           name: CV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,13 @@ jobs:
         uses: docker://pandoc/core:2.9
         with:
           args: "--from markdown --to html --css ./core-styles.css --lua-filter ./pagebreak.lua -o output/index.html --standalone index.md"
+      - name: Install SSH Client
+        uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
       - name: Deploy to pages branch
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          SSH: true
           BRANCH: gh-pages
           FOLDER: output


### PR DESCRIPTION
Uses pandoc to build an HTML file from the repo on commit. Published via `gh-pages` branch.